### PR TITLE
Implement pending tag number updates in SealCard and TagIDOutlinedTextField

### DIFF
--- a/AndroidStudioProjects/WeddellSealMarkRecap/app/build.gradle.kts
+++ b/AndroidStudioProjects/WeddellSealMarkRecap/app/build.gradle.kts
@@ -151,6 +151,9 @@ dependencies {
     testImplementation("androidx.test.ext:junit:1.2.1")
     testImplementation("org.robolectric:robolectric:4.14.1")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+    // Compose UI tests on JVM (Robolectric), e.g. TagIdSectionCommitTest
+    testImplementation(platform("androidx.compose:compose-bom:2025.03.00"))
+    testImplementation("androidx.compose.ui:ui-test-junit4")
 
     implementation("androidx.test:runner:1.6.2")
     implementation("androidx.test:core:1.6.1")

--- a/AndroidStudioProjects/WeddellSealMarkRecap/app/src/androidTest/java/weddellseal/markrecap/TagRetagSaveInstrumentedTest.kt
+++ b/AndroidStudioProjects/WeddellSealMarkRecap/app/src/androidTest/java/weddellseal/markrecap/TagRetagSaveInstrumentedTest.kt
@@ -1,0 +1,262 @@
+package weddellseal.markrecap
+
+import android.Manifest
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextReplacement
+import androidx.lifecycle.ViewModelProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import weddellseal.markrecap.domain.tagretag.data.SealCondition
+import weddellseal.markrecap.domain.tagretag.data.SealType
+import weddellseal.markrecap.domain.tagretag.data.TagEventType
+import weddellseal.markrecap.frameworks.google.fusedLocation.FusedLocationSource
+import weddellseal.markrecap.frameworks.room.observations.ObservationRecord
+import weddellseal.markrecap.frameworks.room.observers.ObserversRepository
+import weddellseal.markrecap.frameworks.room.wedCheck.WedCheckRepository
+import weddellseal.markrecap.frameworks.room.sealColonies.SealColonyRepository
+import weddellseal.markrecap.ui.home.HomeViewModel
+import weddellseal.markrecap.ui.tagretag.TagRetagViewModel
+import weddellseal.markrecap.viewmodelfactories.HomeViewModelFactory
+import weddellseal.markrecap.viewmodelfactories.TagRetagViewModelFactory
+
+/**
+ * End-to-end regression for pending Tag ID edits: user commits tag number 456 via the UI,
+ * re-types 789 in the Tag ID field, and taps Save without blurring the field. The saved
+ * observation must contain 789A (alpha is preset; this test targets pending number commits).
+ *
+ * Uses public UI text/semantics only (no production test hooks). Non-tag required fields are
+ * set on [TagRetagViewModel]; tag entry uses the real [TagIDOutlinedTextField].
+ */
+@RunWith(AndroidJUnit4::class)
+class TagRetagSaveInstrumentedTest {
+
+    companion object {
+        /** Primary seal tag row label when tag event is not Retag. */
+        private const val TAG_ID_LABEL = "Tag ID"
+        /** [TagIDOutlinedTextField] label / placeholder (public UI strings). */
+        private const val TAG_NUMBER_LABEL = "3 or 4 Digit Tag Number"
+        private const val TAG_NUMBER_PLACEHOLDER = "Enter Tag Number"
+        /** UI only offers A, C, D. */
+        private const val TAG_ALPHA = "A"
+    }
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        Manifest.permission.ACCESS_FINE_LOCATION,
+        Manifest.permission.ACCESS_COARSE_LOCATION,
+    )
+
+    private val app: ObservationLogApplication
+        get() = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as ObservationLogApplication
+
+    /**
+     * Tag number [OutlinedTextField]. The "Tag ID" label is a sibling, not an ancestor, so match
+     * on the field's own label or placeholder from [TagIDOutlinedTextField].
+     */
+    private val primaryTagNumberFieldMatcher: SemanticsMatcher
+        get() = hasSetTextAction().and(
+            hasText(TAG_NUMBER_LABEL, substring = true)
+                .or(hasText(TAG_NUMBER_PLACEHOLDER, substring = true)),
+        )
+
+    private fun openDrawer() {
+        composeRule.onNode(hasContentDescription("Toggle drawer"), useUnmergedTree = true)
+            .performClick()
+        composeRule.waitForIdle()
+    }
+
+    private fun clickDrawerItem(text: String) {
+        val node = composeRule.onNodeWithText(text, useUnmergedTree = true)
+        try {
+            node.performScrollTo()
+        } catch (_: AssertionError) {
+            // Drawer item may not be in a scrollable parent.
+        }
+        node.performClick()
+        composeRule.waitForIdle()
+    }
+
+    private fun navigateToTagRetag() {
+        openDrawer()
+        clickDrawerItem("Tag/Retag")
+        composeRule.onNodeWithText("Tag / Retag", substring = true).assertIsDisplayed()
+    }
+
+    private fun clearAllObservations() {
+        runBlocking {
+            app.observationRepo.deleteAll()
+        }
+    }
+
+    private fun getHomeViewModel(): HomeViewModel {
+        val activity = composeRule.activity
+        val factory = HomeViewModelFactory(
+            FusedLocationSource(activity),
+            SealColonyRepository(app.getSealColoniesDao()),
+            ObserversRepository(app.getObserversDao()),
+        )
+        return ViewModelProvider(activity, factory)[HomeViewModel::class.java]
+    }
+
+    private fun getTagRetagViewModel(homeViewModel: HomeViewModel): TagRetagViewModel {
+        val factory = TagRetagViewModelFactory(
+            app,
+            app.observationRepo,
+            WedCheckRepository(app.getWedCheckDao(), app.getFileUploadDao()),
+            homeViewModel.metadata,
+            homeViewModel.uiState,
+        )
+        return ViewModelProvider(composeRule.activity, factory)[TagRetagViewModel::class.java]
+    }
+
+    private fun setupTestObservers() {
+        val homeViewModel = getHomeViewModel()
+        composeRule.runOnUiThread {
+            homeViewModel.updateObserversSelection(listOf("TST"))
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun prefillSealExceptTag(tagRetagViewModel: TagRetagViewModel) {
+        composeRule.runOnUiThread {
+            tagRetagViewModel.prefillSingleMale()
+            tagRetagViewModel.updateCondition(SealType.PRIMARY, SealCondition.GOOD)
+            tagRetagViewModel.updateTagEventType(
+                tagRetagViewModel.primarySeal.value,
+                TagEventType.NEW,
+            )
+            tagRetagViewModel.updateNumTags(SealType.PRIMARY, "1")
+            // Alpha buttons are not reliably exposed to UI tests on device; this test targets
+            // pending tag *number* commits on save, not alpha selection.
+            tagRetagViewModel.updateTagAlpha(SealType.PRIMARY, TAG_ALPHA)
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun scrollToTagIdSection() {
+        composeRule.onNodeWithText(TAG_ID_LABEL, useUnmergedTree = true).performScrollTo()
+        composeRule.waitForIdle()
+    }
+
+    private fun waitUntilTagIdSectionReady() {
+        composeRule.waitUntil(timeoutMillis = 15_000) {
+            composeRule.onAllNodes(hasText(TAG_ID_LABEL, substring = true), useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+    }
+
+    private fun primaryTagNumberField() =
+        if (composeRule.onAllNodes(primaryTagNumberFieldMatcher, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        ) {
+            composeRule.onNode(primaryTagNumberFieldMatcher, useUnmergedTree = true)
+        } else {
+            // Label/placeholder can be on a separate semantics node from the editable text.
+            // On the primary seal card the tag field is the first editable above the comment box.
+            composeRule.onAllNodes(hasSetTextAction(), useUnmergedTree = true)[0]
+        }
+
+    /** Commits the tag number by clearing focus (same as tapping outside the field). */
+    private fun commitTagNumberField() {
+        composeRule.onNodeWithText(TAG_ID_LABEL, useUnmergedTree = true).performClick()
+        composeRule.waitForIdle()
+    }
+
+    /** Types [number] and commits it by blurring the field. */
+    private fun enterAndCommitTagNumber(number: String) {
+        scrollToTagIdSection()
+        waitUntilTagIdSectionReady()
+        val field = primaryTagNumberField()
+        field.performClick()
+        field.performTextReplacement(number)
+        commitTagNumberField()
+    }
+
+    private fun replaceTagNumberWithoutBlur(number: String) {
+        scrollToTagIdSection()
+        val field = primaryTagNumberField()
+        field.performClick()
+        field.performTextReplacement(number)
+        composeRule.waitForIdle()
+    }
+
+    private fun tapSave() {
+        composeRule.waitUntil(timeoutMillis = 15_000) {
+            composeRule.onAllNodes(hasContentDescription("Save Seal"), useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        try {
+            composeRule.onNodeWithText("# of Tags", useUnmergedTree = true).performScrollTo()
+            composeRule.waitForIdle()
+        } catch (_: AssertionError) {
+            // Footer may already be visible on tall layouts.
+        }
+        composeRule.onNode(hasContentDescription("Save Seal"), useUnmergedTree = true)
+            .performClick()
+        composeRule.waitForIdle()
+    }
+
+    private fun waitForObservation(
+        timeoutMillis: Long = 15_000,
+        predicate: (ObservationRecord) -> Boolean,
+    ): ObservationRecord {
+        var found: ObservationRecord? = null
+        composeRule.waitUntil(timeoutMillis) {
+            val match = runBlocking {
+                app.observationRepo.currentObservationsDescByID.first()
+                    .firstOrNull(predicate)
+            }
+            if (match != null) {
+                found = match
+                true
+            } else {
+                false
+            }
+        }
+        return found!!
+    }
+
+    @Test
+    fun saveTagRetag_persistsInProgressTagIdWithoutRequiringBlur() {
+        clearAllObservations()
+        setupTestObservers()
+        navigateToTagRetag()
+
+        prefillSealExceptTag(getTagRetagViewModel(getHomeViewModel()))
+
+        enterAndCommitTagNumber("456")
+        replaceTagNumberWithoutBlur("789")
+        tapSave()
+
+        val expectedTagId = "789$TAG_ALPHA"
+        val saved = waitForObservation { it.tagIDOne == expectedTagId }
+        assertEquals(
+            "Save should persist the in-progress Tag ID edit even when the field still has focus",
+            expectedTagId,
+            saved.tagIDOne,
+        )
+        assertEquals(TagEventType.NEW.alpha, saved.tagEvent)
+    }
+}

--- a/AndroidStudioProjects/WeddellSealMarkRecap/app/src/androidTest/java/weddellseal/markrecap/TagRetagSaveInstrumentedTest.kt
+++ b/AndroidStudioProjects/WeddellSealMarkRecap/app/src/androidTest/java/weddellseal/markrecap/TagRetagSaveInstrumentedTest.kt
@@ -1,6 +1,7 @@
 package weddellseal.markrecap
 
 import android.Manifest
+import android.os.SystemClock
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasContentDescription
@@ -18,6 +19,7 @@ import androidx.test.rule.GrantPermissionRule
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,24 +37,23 @@ import weddellseal.markrecap.viewmodelfactories.HomeViewModelFactory
 import weddellseal.markrecap.viewmodelfactories.TagRetagViewModelFactory
 
 /**
- * End-to-end regression for pending Tag ID edits: user commits tag number 456 via the UI,
- * re-types 789 in the Tag ID field, and taps Save without blurring the field. The saved
- * observation must contain 789A (alpha is preset; this test targets pending number commits).
+ * Regression for pending Tag ID edits on save: after tag 456 is committed, the user re-types 789
+ * in [TagIDOutlinedTextField] and taps Save without blurring. The saved observation must be 789A.
  *
- * Uses public UI text/semantics only (no production test hooks). Non-tag required fields are
- * set on [TagRetagViewModel]; tag entry uses the real [TagIDOutlinedTextField].
+ * Blur/commit behavior is covered by JVM tests ([TagIdSectionCommitTest],
+ * [TagRetagViewModelTest]). This test uses the ViewModel only for non-tag setup and the initial
+ * committed tag number, then drives the in-progress edit and Save through public UI semantics.
  */
 @RunWith(AndroidJUnit4::class)
 class TagRetagSaveInstrumentedTest {
 
     companion object {
-        /** Primary seal tag row label when tag event is not Retag. */
         private const val TAG_ID_LABEL = "Tag ID"
-        /** [TagIDOutlinedTextField] label / placeholder (public UI strings). */
         private const val TAG_NUMBER_LABEL = "3 or 4 Digit Tag Number"
         private const val TAG_NUMBER_PLACEHOLDER = "Enter Tag Number"
-        /** UI only offers A, C, D. */
         private const val TAG_ALPHA = "A"
+        private const val COMMITTED_TAG_NUMBER = "456"
+        private const val IN_PROGRESS_TAG_NUMBER = "789"
     }
 
     @get:Rule
@@ -68,12 +69,11 @@ class TagRetagSaveInstrumentedTest {
         get() = InstrumentationRegistry.getInstrumentation()
             .targetContext.applicationContext as ObservationLogApplication
 
-    /**
-     * Tag number [OutlinedTextField]. The "Tag ID" label is a sibling, not an ancestor, so match
-     * on the field's own label or placeholder from [TagIDOutlinedTextField].
-     */
-    private val primaryTagNumberFieldMatcher: SemanticsMatcher
-        get() = hasSetTextAction().and(
+    private fun tagNumberFieldMatcher(displayedNumber: String): SemanticsMatcher =
+        hasSetTextAction().and(hasText(displayedNumber))
+
+    private fun tagNumberFieldMatcherFallback(): SemanticsMatcher =
+        hasSetTextAction().and(
             hasText(TAG_NUMBER_LABEL, substring = true)
                 .or(hasText(TAG_NUMBER_PLACEHOLDER, substring = true)),
         )
@@ -81,6 +81,16 @@ class TagRetagSaveInstrumentedTest {
     private fun openDrawer() {
         composeRule.onNode(hasContentDescription("Toggle drawer"), useUnmergedTree = true)
             .performClick()
+        composeRule.waitForIdle()
+    }
+
+    /** Scrolls [matcher] into view when it lives inside a scrollable parent. */
+    private fun scrollIntoView(matcher: SemanticsMatcher) {
+        try {
+            composeRule.onNode(matcher, useUnmergedTree = true).performScrollTo()
+        } catch (_: AssertionError) {
+            // Already visible or not in a scrollable parent.
+        }
         composeRule.waitForIdle()
     }
 
@@ -134,9 +144,16 @@ class TagRetagSaveInstrumentedTest {
             homeViewModel.updateObserversSelection(listOf("TST"))
         }
         composeRule.waitForIdle()
+        composeRule.waitUntil(timeoutMillis = 15_000) {
+            var valid = false
+            composeRule.runOnUiThread {
+                valid = homeViewModel.metadata.value.isValid
+            }
+            valid
+        }
     }
 
-    private fun prefillSealExceptTag(tagRetagViewModel: TagRetagViewModel) {
+    private fun prefillSealAndCommitTag(tagRetagViewModel: TagRetagViewModel) {
         composeRule.runOnUiThread {
             tagRetagViewModel.prefillSingleMale()
             tagRetagViewModel.updateCondition(SealType.PRIMARY, SealCondition.GOOD)
@@ -145,112 +162,123 @@ class TagRetagSaveInstrumentedTest {
                 TagEventType.NEW,
             )
             tagRetagViewModel.updateNumTags(SealType.PRIMARY, "1")
-            // Alpha buttons are not reliably exposed to UI tests on device; this test targets
-            // pending tag *number* commits on save, not alpha selection.
             tagRetagViewModel.updateTagAlpha(SealType.PRIMARY, TAG_ALPHA)
+            tagRetagViewModel.updateTagNumber(SealType.PRIMARY, COMMITTED_TAG_NUMBER)
         }
         composeRule.waitForIdle()
     }
 
     private fun scrollToTagIdSection() {
-        composeRule.onNodeWithText(TAG_ID_LABEL, useUnmergedTree = true).performScrollTo()
-        composeRule.waitForIdle()
-    }
-
-    private fun waitUntilTagIdSectionReady() {
         composeRule.waitUntil(timeoutMillis = 15_000) {
             composeRule.onAllNodes(hasText(TAG_ID_LABEL, substring = true), useUnmergedTree = true)
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
+        scrollIntoView(hasText(TAG_ID_LABEL, substring = true))
     }
 
-    private fun primaryTagNumberField() =
-        if (composeRule.onAllNodes(primaryTagNumberFieldMatcher, useUnmergedTree = true)
+    private fun waitUntilTagNumberFieldShows(number: String) {
+        composeRule.waitUntil(timeoutMillis = 15_000) {
+            composeRule.onAllNodes(tagNumberFieldMatcher(number), useUnmergedTree = true)
                 .fetchSemanticsNodes()
-                .isNotEmpty()
+                .isNotEmpty() ||
+                composeRule.onAllNodes(tagNumberFieldMatcherFallback(), useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+        }
+    }
+
+    private fun tagNumberFieldMatcherResolved(): SemanticsMatcher =
+        if (composeRule.onAllNodes(
+                tagNumberFieldMatcher(COMMITTED_TAG_NUMBER),
+                useUnmergedTree = true,
+            ).fetchSemanticsNodes().isNotEmpty()
         ) {
-            composeRule.onNode(primaryTagNumberFieldMatcher, useUnmergedTree = true)
+            tagNumberFieldMatcher(COMMITTED_TAG_NUMBER)
         } else {
-            // Label/placeholder can be on a separate semantics node from the editable text.
-            // On the primary seal card the tag field is the first editable above the comment box.
-            composeRule.onAllNodes(hasSetTextAction(), useUnmergedTree = true)[0]
+            tagNumberFieldMatcherFallback()
         }
 
-    /** Commits the tag number by clearing focus (same as tapping outside the field). */
-    private fun commitTagNumberField() {
-        composeRule.onNodeWithText(TAG_ID_LABEL, useUnmergedTree = true).performClick()
-        composeRule.waitForIdle()
-    }
-
-    /** Types [number] and commits it by blurring the field. */
-    private fun enterAndCommitTagNumber(number: String) {
-        scrollToTagIdSection()
-        waitUntilTagIdSectionReady()
-        val field = primaryTagNumberField()
-        field.performClick()
-        field.performTextReplacement(number)
-        commitTagNumberField()
+    /**
+     * Re-fetch the matcher on each attempt. [performTextReplacement] focuses the field and can
+     * trigger recomposition; avoid [performClick] first, which was dropping the semantics node on
+     * API 36 before text could be entered.
+     */
+    private fun replaceTextWithRetry(matcher: SemanticsMatcher, number: String, attempts: Int = 5) {
+        var lastError: AssertionError? = null
+        repeat(attempts) {
+            composeRule.waitForIdle()
+            try {
+                composeRule.onNode(matcher, useUnmergedTree = true).performTextReplacement(number)
+                composeRule.waitForIdle()
+                return
+            } catch (error: AssertionError) {
+                lastError = error
+                Thread.sleep(150)
+            }
+        }
+        throw lastError!!
     }
 
     private fun replaceTagNumberWithoutBlur(number: String) {
         scrollToTagIdSection()
-        val field = primaryTagNumberField()
-        field.performClick()
-        field.performTextReplacement(number)
+        waitUntilTagNumberFieldShows(COMMITTED_TAG_NUMBER)
         composeRule.waitForIdle()
+        replaceTextWithRetry(tagNumberFieldMatcherResolved(), number)
+    }
+
+    private fun waitUntilSaveEnabled(tagRetagViewModel: TagRetagViewModel) {
+        composeRule.waitUntil(timeoutMillis = 15_000) {
+            var enabled = false
+            composeRule.runOnUiThread {
+                enabled = tagRetagViewModel.uiState.value.isSaveEnabled
+            }
+            enabled
+        }
     }
 
     private fun tapSave() {
-        composeRule.waitUntil(timeoutMillis = 15_000) {
-            composeRule.onAllNodes(hasContentDescription("Save Seal"), useUnmergedTree = true)
-                .fetchSemanticsNodes()
-                .isNotEmpty()
-        }
-        try {
-            composeRule.onNodeWithText("# of Tags", useUnmergedTree = true).performScrollTo()
-            composeRule.waitForIdle()
-        } catch (_: AssertionError) {
-            // Footer may already be visible on tall layouts.
-        }
+        scrollIntoView(hasContentDescription("Save Seal"))
         composeRule.onNode(hasContentDescription("Save Seal"), useUnmergedTree = true)
             .performClick()
         composeRule.waitForIdle()
     }
 
     private fun waitForObservation(
-        timeoutMillis: Long = 15_000,
+        timeoutMillis: Long = 20_000,
         predicate: (ObservationRecord) -> Boolean,
     ): ObservationRecord {
-        var found: ObservationRecord? = null
-        composeRule.waitUntil(timeoutMillis) {
-            val match = runBlocking {
+        val deadline = SystemClock.uptimeMillis() + timeoutMillis
+        var lastTagIds: List<String> = emptyList()
+        while (SystemClock.uptimeMillis() < deadline) {
+            val records = runBlocking {
                 app.observationRepo.currentObservationsDescByID.first()
-                    .firstOrNull(predicate)
             }
-            if (match != null) {
-                found = match
-                true
-            } else {
-                false
-            }
+            lastTagIds = records.map { it.tagIDOne }
+            records.firstOrNull(predicate)?.let { return it }
+            Thread.sleep(250)
         }
-        return found!!
+        throw AssertionError(
+            "No matching observation within ${timeoutMillis}ms. " +
+                "Saved tagIDOne values: $lastTagIds",
+        )
     }
 
     @Test
     fun saveTagRetag_persistsInProgressTagIdWithoutRequiringBlur() {
         clearAllObservations()
         setupTestObservers()
+
+        val homeViewModel = getHomeViewModel()
+        val tagRetagViewModel = getTagRetagViewModel(homeViewModel)
+        prefillSealAndCommitTag(tagRetagViewModel)
         navigateToTagRetag()
 
-        prefillSealExceptTag(getTagRetagViewModel(getHomeViewModel()))
-
-        enterAndCommitTagNumber("456")
-        replaceTagNumberWithoutBlur("789")
+        replaceTagNumberWithoutBlur(IN_PROGRESS_TAG_NUMBER)
+        waitUntilSaveEnabled(tagRetagViewModel)
         tapSave()
 
-        val expectedTagId = "789$TAG_ALPHA"
+        val expectedTagId = "$IN_PROGRESS_TAG_NUMBER$TAG_ALPHA"
         val saved = waitForObservation { it.tagIDOne == expectedTagId }
         assertEquals(
             "Save should persist the in-progress Tag ID edit even when the field still has focus",
@@ -258,5 +286,6 @@ class TagRetagSaveInstrumentedTest {
             saved.tagIDOne,
         )
         assertEquals(TagEventType.NEW.alpha, saved.tagEvent)
+        assertTrue(saved.observerInitials.contains("TST"))
     }
 }

--- a/AndroidStudioProjects/WeddellSealMarkRecap/app/src/main/java/weddellseal/markrecap/ui/tagretag/SealCard.kt
+++ b/AndroidStudioProjects/WeddellSealMarkRecap/app/src/main/java/weddellseal/markrecap/ui/tagretag/SealCard.kt
@@ -224,6 +224,7 @@ fun SealCard(
                     viewModel.removeWedCheckMatch(seal.sealType)
                 }
             },
+            onNumberChanged = { viewModel.updatePendingTagNumber(seal.sealType, it) },
             onNumberCommitted = { viewModel.updateTagNumber(seal.sealType, it) },
             onAlphaSelected = { viewModel.updateTagAlpha(seal.sealType, it) },
             modifier = Modifier.clearFocusOnTap(focusManager)
@@ -239,6 +240,7 @@ fun SealCard(
                     viewModel.clearOldTag(seal.sealType)
                     viewModel.removeWedCheckMatch(seal.sealType)
                 },
+                onNumberChanged = { viewModel.updatePendingOldTagNumber(seal.sealType, it) },
                 onNumberCommitted = {
                     viewModel.updateOldTagNumber(
                         seal.sealType,

--- a/AndroidStudioProjects/WeddellSealMarkRecap/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagIDOutlinedTextField.kt
+++ b/AndroidStudioProjects/WeddellSealMarkRecap/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagIDOutlinedTextField.kt
@@ -46,8 +46,12 @@ fun TagIDOutlinedTextField(
 
     var text by remember { mutableStateOf(value) } //used to prevent the model update until the user is done typing
 
-    LaunchedEffect(value) {
-        text = value
+    // Sync from the model only when not focused; otherwise recomposition can reset in-progress
+    // edits (pending tag number) back to the last committed value.
+    LaunchedEffect(value, isFocused) {
+        if (!isFocused) {
+            text = value
+        }
     }
 
     OutlinedTextField(

--- a/AndroidStudioProjects/WeddellSealMarkRecap/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagIDOutlinedTextField.kt
+++ b/AndroidStudioProjects/WeddellSealMarkRecap/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagIDOutlinedTextField.kt
@@ -33,6 +33,7 @@ fun TagIDOutlinedTextField(
     placeholderText: String,
     keyboardType: KeyboardType,
     onClearValueDo: () -> Unit,
+    onValueChange: (String) -> Unit = {},
     onFocusChange: (Boolean, String) -> Unit // Pass both focus state and latest value
 ) {
     val focusManager =
@@ -54,6 +55,7 @@ fun TagIDOutlinedTextField(
         onValueChange = {
             val sanitized = it.replace(Regex("[^0-9]"), "") // only allow numeric characters
             text = sanitized.trim()
+            onValueChange(text)
         },
         label = { Text(labelText) },
         placeholder = { Text(placeholderText) },

--- a/AndroidStudioProjects/WeddellSealMarkRecap/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagRetagViewModel.kt
+++ b/AndroidStudioProjects/WeddellSealMarkRecap/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagRetagViewModel.kt
@@ -102,6 +102,10 @@ class TagRetagViewModel(
     private var originalPupOne: Seal? = null
     private var originalPupTwo: Seal? = null
 
+    /** BUG FIX: In-progress tag numbers from [TagIDOutlinedTextField] before blur commits to the seal model. */
+    private val pendingTagNumbers = mutableMapOf<SealType, String>()
+    private val pendingOldTagNumbers = mutableMapOf<SealType, String>()
+
     //    init {
 //        // Automatically update colonyLocation if it's set to ""
 //        // In other words, if the user has not selected a location, use the auto-detected location
@@ -274,6 +278,8 @@ class TagRetagViewModel(
         originalPrimarySeal = null
         originalPupOne = null
         originalPupTwo = null
+        pendingTagNumbers.clear()
+        pendingOldTagNumbers.clear()
     }
 
     fun setIsSaving() {
@@ -642,6 +648,25 @@ class TagRetagViewModel(
         }
     }
 
+    fun updatePendingTagNumber(sealType: SealType, input: String) {
+        if (sealType == SealType.UNKNOWN) return
+        pendingTagNumbers[sealType] = input
+    }
+
+    fun updatePendingOldTagNumber(sealType: SealType, input: String) {
+        if (sealType == SealType.UNKNOWN) return
+        pendingOldTagNumbers[sealType] = input
+    }
+
+    private fun commitPendingTagNumbers() {
+        pendingTagNumbers.toMap().forEach { (sealType, number) ->
+            updateTagNumber(sealType, number)
+        }
+        pendingOldTagNumbers.toMap().forEach { (sealType, number) ->
+            updateOldTagNumber(sealType, number)
+        }
+    }
+
     // TODO, why is this a string input and not a numeric input, see updateOldTagNumber
     fun updateTagNumber(sealType: SealType, input: String) {
         var tagNumber = input
@@ -673,6 +698,7 @@ class TagRetagViewModel(
                 // No action needed for UNKNOWN
             }
         }
+        pendingTagNumbers.remove(sealType)
     }
 
     fun updateTagAlpha(sealType: SealType, input: String) {
@@ -725,6 +751,7 @@ class TagRetagViewModel(
                 // No action needed for UNKNOWN
             }
         }
+        pendingOldTagNumbers.remove(sealType)
     }
 
     fun updateOldTagAlpha(sealType: SealType, input: String) {
@@ -1402,6 +1429,8 @@ class TagRetagViewModel(
         currentLocation: GeoLocation?,
     ) {
         Log.i("writeObservationRecord", "latitude at time of write: ${currentLocation?.coordinates?.latitude}")
+
+        commitPendingTagNumbers()
 
         if (uiState.value.isEditMode) {
 

--- a/AndroidStudioProjects/WeddellSealMarkRecap/app/src/main/java/weddellseal/markrecap/ui/tagretag/sealcard/TagIDSection.kt
+++ b/AndroidStudioProjects/WeddellSealMarkRecap/app/src/main/java/weddellseal/markrecap/ui/tagretag/sealcard/TagIDSection.kt
@@ -27,6 +27,7 @@ private val TAG_ALPHAS = listOf("A", "C", "D")
     number: String,
     alpha: String,
     onClear: () -> Unit,
+    onNumberChanged: (String) -> Unit = {},
     onNumberCommitted: (String) -> Unit,
     onAlphaSelected: (String) -> Unit,
     modifier: Modifier
@@ -57,6 +58,7 @@ private val TAG_ALPHAS = listOf("A", "C", "D")
                     placeholderText = "Enter Tag Number",
                     keyboardType = KeyboardType.Number,
                     onClearValueDo = onClear,
+                    onValueChange = onNumberChanged,
                     onFocusChange = { isFocused, lastValue ->
                         if (!isFocused) onNumberCommitted(lastValue)
                     }

--- a/AndroidStudioProjects/WeddellSealMarkRecap/app/src/test/java/weddellseal/markrecap/ui/tagretag/TagRetagViewModelTest.kt
+++ b/AndroidStudioProjects/WeddellSealMarkRecap/app/src/test/java/weddellseal/markrecap/ui/tagretag/TagRetagViewModelTest.kt
@@ -79,4 +79,46 @@ class TagRetagViewModelTest {
         assertEquals("456B", written[0].tagIDOne)
         assertEquals(TagEventType.NEW.alpha, written[0].tagEvent)
     }
+
+    /**
+     * Models: user entered tag 456B, moved to another field (committed), then returned to Tag ID,
+     * changed it to 789B, and tapped Save without blurring the Tag ID field. The ViewModel still
+     * holds 456B because [TagIdSection] only commits on focus loss.
+     */
+    @Test
+    fun writeObservationRecord_persistsReEditedTagNumberWithoutRequiringBlur() = runTest {
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        val metadata = MutableStateFlow(TestFixtures.sampleMetadata())
+        val homeUi = MutableStateFlow(HomeViewModel.UiState(overrideColony = false))
+        val written = mutableListOf<ObservationRecord>()
+        val observationRepo = mockk<ObservationRepository>()
+        coEvery { observationRepo.writeObservation(any()) } answers {
+            written.add(firstArg())
+        }
+        val wedCheckRepo = mockk<WedCheckRepository>(relaxed = true)
+
+        val vm = TagRetagViewModel(app, observationRepo, wedCheckRepo, metadata, homeUi)
+
+        vm.prefillSingleMale()
+        vm.updateCondition(SealType.PRIMARY, SealCondition.GOOD)
+        vm.updateTagEventType(vm.primarySeal.value, TagEventType.NEW)
+        vm.updateTagNumber(SealType.PRIMARY, "456")
+        vm.updateTagAlpha(SealType.PRIMARY, "B")
+        vm.updateNumTags(SealType.PRIMARY, "1")
+
+        // User re-edits Tag ID in the UI to 789B but Save is tapped before the field blurs,
+        // so updateTagNumber is never called with "789" (only updatePendingTagNumber, on each keystroke).
+        vm.updatePendingTagNumber(SealType.PRIMARY, "789")
+        assertEquals("456", vm.primarySeal.value.tagNumber)
+
+        assertTrue(vm.uiState.value.isSaveEnabled)
+        vm.writeObservationRecord(TestFixtures.sampleGeoLocation())
+
+        assertEquals(1, written.size)
+        assertEquals(
+            "Save should persist the in-progress Tag ID edit even when the field still has focus",
+            "789B",
+            written[0].tagIDOne,
+        )
+    }
 }

--- a/AndroidStudioProjects/WeddellSealMarkRecap/app/src/test/java/weddellseal/markrecap/ui/tagretag/sealcard/TagIdSectionCommitTest.kt
+++ b/AndroidStudioProjects/WeddellSealMarkRecap/app/src/test/java/weddellseal/markrecap/ui/tagretag/sealcard/TagIdSectionCommitTest.kt
@@ -1,7 +1,13 @@
 package weddellseal.markrecap.ui.tagretag.sealcard
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -16,9 +22,10 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Regression tests for tag/speno not updating when the user edits Tag ID and taps Save
- * without leaving the field (blur). [TagIdSection] only calls [onNumberCommitted] when
- * the number field loses focus.
+ * Regression tests for tag ID commit and [TagIDOutlinedTextField] model sync:
+ * - [TagIdSection] only calls [onNumberCommitted] on blur.
+ * - While focused, in-progress text must survive parent recomposition when the model
+ *   still holds the last committed number ([TagIDOutlinedTextField] LaunchedEffect guard).
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -78,5 +85,74 @@ class TagIdSectionCommitTest {
 
         composeRule.waitForIdle()
         assertEquals("789", committedNumber)
+    }
+
+    /**
+     * Parent still passes number = "456" while the user has typed 789 with focus. An unrelated
+     * state change forces recomposition; the field must not snap back to 456.
+     */
+    @Test
+    fun tagNumber_retainsInProgressEditWhenParentRecomposesWhileFocused() {
+        val number = mutableStateOf("456")
+        val recomposeKey = mutableIntStateOf(0)
+
+        composeRule.setContent {
+            TagIdSectionHost(
+                number = number.value,
+                recomposeKey = recomposeKey.intValue,
+                onNumberCommitted = {},
+            )
+        }
+
+        composeRule.onNodeWithText("456").performClick()
+        composeRule.onNodeWithText("456").performTextReplacement("789")
+        composeRule.onNodeWithText("789").assertIsFocused()
+
+        recomposeKey.intValue = 1
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("789").assertIsDisplayed()
+        composeRule.onNodeWithText("456").assertDoesNotExist()
+    }
+
+    /** When the field is not focused, a model update should replace what the user sees. */
+    @Test
+    fun tagNumber_syncsFromModelWhenNotFocused() {
+        val number = mutableStateOf("456")
+
+        composeRule.setContent {
+            TagIdSectionHost(
+                number = number.value,
+                recomposeKey = 0,
+                onNumberCommitted = {},
+            )
+        }
+
+        composeRule.onNodeWithText("456").assertIsDisplayed()
+        number.value = "123"
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("123").assertIsDisplayed()
+    }
+}
+
+@Composable
+private fun TagIdSectionHost(
+    number: String,
+    recomposeKey: Int,
+    onNumberCommitted: (String) -> Unit,
+) {
+    MaterialTheme {
+        Column {
+            Text("key=$recomposeKey")
+            TagIdSection(
+                label = "Tag ID",
+                number = number,
+                alpha = "B",
+                onClear = {},
+                onNumberCommitted = onNumberCommitted,
+                onAlphaSelected = {},
+                modifier = Modifier,
+            )
+        }
     }
 }

--- a/AndroidStudioProjects/WeddellSealMarkRecap/app/src/test/java/weddellseal/markrecap/ui/tagretag/sealcard/TagIdSectionCommitTest.kt
+++ b/AndroidStudioProjects/WeddellSealMarkRecap/app/src/test/java/weddellseal/markrecap/ui/tagretag/sealcard/TagIdSectionCommitTest.kt
@@ -1,0 +1,82 @@
+package weddellseal.markrecap.ui.tagretag.sealcard
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression tests for tag/speno not updating when the user edits Tag ID and taps Save
+ * without leaving the field (blur). [TagIdSection] only calls [onNumberCommitted] when
+ * the number field loses focus.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class TagIdSectionCommitTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun tagNumber_isNotCommittedWhileFieldRemainsFocused() {
+        var committedNumber: String? = null
+
+        composeRule.setContent {
+            MaterialTheme {
+                TagIdSection(
+                    label = "Tag ID",
+                    number = "456",
+                    alpha = "B",
+                    onClear = {},
+                    onNumberCommitted = { committedNumber = it },
+                    onAlphaSelected = {},
+                    modifier = Modifier,
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("456").performClick()
+        composeRule.onNodeWithText("456").assertIsFocused()
+        composeRule.onNodeWithText("456").performTextReplacement("789")
+
+        composeRule.waitForIdle()
+        assertNotEquals("789", committedNumber)
+    }
+
+    @Test
+    fun tagNumber_isCommittedWhenFieldLosesFocus() {
+        var committedNumber: String? = null
+
+        composeRule.setContent {
+            MaterialTheme {
+                TagIdSection(
+                    label = "Tag ID",
+                    number = "456",
+                    alpha = "B",
+                    onClear = {},
+                    onNumberCommitted = { committedNumber = it },
+                    onAlphaSelected = {},
+                    modifier = Modifier,
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("456").performClick()
+        composeRule.onNodeWithText("456").performTextReplacement("789")
+        // Tapping an alpha button clears focus from the number field (see SingleSelectTagAlphaButtonGroup).
+        composeRule.onNodeWithText("A").performClick()
+
+        composeRule.waitForIdle()
+        assertEquals("789", committedNumber)
+    }
+}

--- a/AndroidStudioProjects/WeddellSealMarkRecap/app/src/test/resources/README_TESTING.md
+++ b/AndroidStudioProjects/WeddellSealMarkRecap/app/src/test/resources/README_TESTING.md
@@ -30,9 +30,14 @@ cd AndroidStudioProjects/WeddellSealMarkRecap
 Useful variants:
 
 ```bash
-# Run a single test class (example)
+# Run a single test class
 ./gradlew :app:testDebugUnitTest --tests "weddellseal.markrecap.domain.tagretag.data.SealTest"
+
+# Run a single test method
+./gradlew :app:testDebugUnitTest --tests "weddellseal.markrecap.ui.tagretag.sealcard.TagIdSectionCommitTest.tagNumber_isCommittedWhenFieldLosesFocus"
 ```
+
+The `--tests` filter works for JVM unit tests only (not for instrumented tests; see below).
 
 Reports: `app/build/reports/tests/testDebugUnitTest/index.html`
 
@@ -46,6 +51,26 @@ These install a test APK on a **running emulator or USB-connected device** and e
 ```bash
 cd AndroidStudioProjects/WeddellSealMarkRecap
 ./gradlew :app:connectedDebugAndroidTest
+```
+
+**Running one class or method:** `connectedDebugAndroidTest` does **not** support Gradle’s `--tests` option. Pass the class (and optionally method) to the instrumentation runner instead:
+
+```bash
+# Single test class
+./gradlew :app:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=weddellseal.markrecap.TagRetagSaveInstrumentedTest
+
+# Single test method (Class#methodName)
+./gradlew :app:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=weddellseal.markrecap.TagRetagSaveInstrumentedTest#saveTagRetag_persistsInProgressTagIdWithoutRequiringBlur
+```
+
+If more than one device is connected, target one serial (from `adb devices`):
+
+```bash
+./gradlew :app:connectedDebugAndroidTest \
+  --serial emulator-5554 \
+  -Pandroid.testInstrumentationRunnerArguments.class=weddellseal.markrecap.TagRetagSaveInstrumentedTest
 ```
 
 Reports: `app/build/reports/androidTests/connected/index.html` (path may vary slightly by AGP version).


### PR DESCRIPTION

- Added functionality to update pending tag numbers in the ViewModel when the user modifies the tag input fields without losing focus.
- Enhanced SealCard and TagIDOutlinedTextField components to handle onNumberChanged events, allowing real-time updates to pending tag numbers.
- Introduced tests to ensure that tag numbers are correctly persisted even when the input field remains focused during save operations.