### PR TITLE
Add empty state handling for recent observations to fix display issue

### DIFF
--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/recentobservations/ObservationTabbedCards.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/recentobservations/ObservationTabbedCards.kt
@@ -55,6 +55,14 @@ fun ObservationTabbedCards(
         modifier = Modifier
             .fillMaxWidth()
     ) {
+        if (tabItems.isEmpty()) {
+            Text(
+                text = "No observation selected.",
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(24.dp),
+            )
+            return
+        }
 
         PrimaryTabRow(selectedTabIndex = selectedTabIndex) {
             tabItems.forEachIndexed { index, tabItem ->

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/recentobservations/ObservationViewer.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/recentobservations/ObservationViewer.kt
@@ -1,6 +1,5 @@
 package weddellseal.markrecap.ui.recentobservations
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -16,7 +15,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -38,16 +36,11 @@ fun ObservationViewer(
                     titleContentColor = MaterialTheme.colorScheme.primary
                 ),
                 title = {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            "Tag/Retag Viewer",
-                            style = MaterialTheme.typography.titleLarge,
-                            fontSize = 36.sp // Adjust this value as needed
-                        )
-                    }
+                    Text(
+                        text = "Tag/Retag Viewer",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontSize = 36.sp,
+                    )
                 },
                 navigationIcon = {
                     IconButton(onClick = {

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagRetagViewModel.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagRetagViewModel.kt
@@ -150,9 +150,9 @@ class TagRetagViewModel(
     }
 
     fun onViewAttempt(observation: DisplayObservation) {
-        viewModelScope.launch {
-            _selectedRecentObservation.value = observation // set the observation to edit
-        }
+        // Set synchronously so ObservationViewer has data on first composition
+        // (navigation from RecentObservations runs in the same frame).
+        _selectedRecentObservation.value = observation
     }
 
     fun prefillSingleMale() {

--- a/weddell-seal-android/app/src/test/java/weddellseal/markrecap/ui/tagretag/TagRetagViewModelTest.kt
+++ b/weddell-seal-android/app/src/test/java/weddellseal/markrecap/ui/tagretag/TagRetagViewModelTest.kt
@@ -29,6 +29,7 @@ import weddellseal.markrecap.frameworks.room.observations.ObservationRecord
 import weddellseal.markrecap.frameworks.room.observations.ObservationRepository
 import weddellseal.markrecap.frameworks.room.wedCheck.WedCheckRepository
 import weddellseal.markrecap.ui.home.HomeViewModel
+import weddellseal.markrecap.ui.recentobservations.DisplayObservation
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -48,6 +49,23 @@ class TagRetagViewModelTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
+    }
+
+    @Test
+    fun onViewAttempt_setsSelectedObservationBeforeNavigation() = runTest {
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        val metadata = MutableStateFlow(TestFixtures.sampleMetadata())
+        val homeUi = MutableStateFlow(HomeViewModel.UiState(overrideColony = false))
+        val observationRepo = mockk<ObservationRepository>(relaxed = true)
+        val wedCheckRepo = mockk<WedCheckRepository>(relaxed = true)
+        val vm = TagRetagViewModel(app, observationRepo, wedCheckRepo, metadata, homeUi)
+
+        val record = TestFixtures.minimalObservationRecord()
+        val displayObs = DisplayObservation.Standalone(record)
+
+        vm.onViewAttempt(displayObs)
+
+        assertEquals(displayObs, vm.selectedRecentObservation.value)
     }
 
     @Test


### PR DESCRIPTION
- Implemented a message for empty observation lists in ObservationTabbedCards to enhance user experience.
- Simplified the title layout in ObservationViewer by removing unnecessary Box and using a direct Text component.
- Updated TagRetagViewModel to set the selected observation synchronously for immediate data availability during navigation.
- Added a test case to verify that the selected observation is set correctly before navigation in TagRetagViewModelTest.