### PR TITLE
Fix to include retag reason in comment

### DIFF
--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/utils/BuildObservationRecord.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/utils/BuildObservationRecord.kt
@@ -115,8 +115,8 @@ fun buildObservationRecord(
     if (seal.oldTagMarks) {
         sb.append("old tag marks; ")
     }
-    // TODO, write a test to validate that if the tagEvent is retag and a reason is selected, that this logic does not populate the value because the comparisons should be != and not ==
-    if (seal.tagEventType == TagEventType.RETAG && (seal.reasonForRetag == RetagReason.NONE || seal.reasonForRetag == RetagReason.UNKNOWN)) {
+    // if the tagEvent is retag and a reason is selected, add the retag reason to the comment
+    if (seal.tagEventType == TagEventType.RETAG && (seal.reasonForRetag != RetagReason.NONE && seal.reasonForRetag != RetagReason.UNKNOWN)) {
         sb.append("Reason for Retag: ${seal.reasonForRetag.description}; ")
     }
 
@@ -125,7 +125,7 @@ fun buildObservationRecord(
     var date = getCurrentDateFormatted()
     var time = getCurrentTimeFormatted()
 
-    // TODO, test when a parent seal has no changes but the pup does
+    // TODO, test when a parent seal has no changes but the pup does not
     if (seal.hasEdits) {
         sb.append("Edited $date at $time: $edits; ") // date that the record was edited + the edits made
         date = metadata.originalDate // for edited records, the original date should be retained

--- a/weddell-seal-android/app/src/test/java/weddellseal/markrecap/ui/tagretag/utils/BuildObservationRecordTest.kt
+++ b/weddell-seal-android/app/src/test/java/weddellseal/markrecap/ui/tagretag/utils/BuildObservationRecordTest.kt
@@ -1,6 +1,7 @@
 package weddellseal.markrecap.ui.tagretag.utils
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import weddellseal.markrecap.TestFixtures
@@ -121,6 +122,38 @@ class BuildObservationRecordTest {
         assertTrue(record.comments.contains("edited note"))
         assertEquals("2024-06-01", record.date)
         assertEquals("08:00:00", record.time)
+    }
+
+    @Test
+    fun retagWithSelectedReasonIncludesReasonInComments() {
+        val seal = Seal(
+            sealType = SealType.PRIMARY,
+            ageClass = SealAgeClass.ADULT,
+            sex = SealSex.FEMALE,
+            numRelatives = SealRelatives.ZERO,
+            tagEventType = TagEventType.RETAG,
+            tagNumber = "111",
+            tagAlpha = "A",
+            numTags = "1",
+            oldTagNumber = "222",
+            oldTagAlpha = "B",
+            reasonForRetag = RetagReason.ONE_OF_FOUR,
+            condition = SealCondition.GOOD,
+        )
+
+        val record = buildObservationRecord(
+            null,
+            seal,
+            "",
+            "",
+            "",
+            TestFixtures.sampleMetadata(),
+        )
+
+        assertEquals(RetagReason.ONE_OF_FOUR.description, record.retagReason)
+        assertTrue(
+            record.comments.contains("Reason for Retag: ${RetagReason.ONE_OF_FOUR.description}"),
+        )
     }
 
     @Test

--- a/weddell-seal-android/app/src/test/java/weddellseal/markrecap/ui/tagretag/utils/BuildObservationRecordTest.kt
+++ b/weddell-seal-android/app/src/test/java/weddellseal/markrecap/ui/tagretag/utils/BuildObservationRecordTest.kt
@@ -157,6 +157,61 @@ class BuildObservationRecordTest {
     }
 
     @Test
+    fun retagWithNoneOrUnknownReasonOmitsReasonFromComments() {
+        listOf(RetagReason.NONE, RetagReason.UNKNOWN).forEach { reason ->
+            val record = buildObservationRecord(
+                null,
+                retagSeal(reasonForRetag = reason),
+                "",
+                "",
+                "",
+                TestFixtures.sampleMetadata(),
+            )
+
+            assertEquals(reason.description, record.retagReason)
+            assertFalse(record.comments.contains("Reason for Retag:"))
+        }
+    }
+
+    @Test
+    fun nonRetagEventOmitsReasonFromCommentsEvenWhenReasonSet() {
+        val seal = retagSeal(reasonForRetag = RetagReason.OTHER)
+            .copy(tagEventType = TagEventType.NEW)
+
+        val record = buildObservationRecord(
+            null,
+            seal,
+            "",
+            "",
+            "",
+            TestFixtures.sampleMetadata(),
+        )
+
+        assertFalse(record.comments.contains("Reason for Retag:"))
+    }
+
+    @Test
+    fun retagReasonAppearsBeforeUserCommentInCommentString() {
+        val record = buildObservationRecord(
+            null,
+            retagSeal(reasonForRetag = RetagReason.OTHER).copy(
+                pupPeed = true,
+                comment = "field note",
+            ),
+            "",
+            "",
+            "",
+            TestFixtures.sampleMetadata(),
+        )
+
+        val reasonSnippet = "Reason for Retag: Other;"
+        assertTrue(record.comments.startsWith("pup peed; "))
+        assertTrue(record.comments.contains(reasonSnippet))
+        assertTrue(record.comments.endsWith("field note"))
+        assertTrue(record.comments.indexOf(reasonSnippet) < record.comments.indexOf("field note"))
+    }
+
+    @Test
     fun dateTimeUsesCurrentWhenNoEdits() {
         val seal = TestFixtures.completePrimaryNewSeal()
         val record = buildObservationRecord(null, seal, "", "", "", TestFixtures.sampleMetadata())
@@ -164,4 +219,21 @@ class BuildObservationRecordTest {
         assertTrue(record.date.matches(Regex("\\d{4}-\\d{2}-\\d{2}")))
         assertTrue(record.time.matches(Regex("\\d{2}:\\d{2}:\\d{2}")))
     }
+
+    private fun retagSeal(
+        reasonForRetag: RetagReason = RetagReason.ONE_OF_FOUR,
+    ) = Seal(
+        sealType = SealType.PRIMARY,
+        ageClass = SealAgeClass.ADULT,
+        sex = SealSex.FEMALE,
+        numRelatives = SealRelatives.ZERO,
+        tagEventType = TagEventType.RETAG,
+        tagNumber = "111",
+        tagAlpha = "A",
+        numTags = "1",
+        oldTagNumber = "222",
+        oldTagAlpha = "B",
+        reasonForRetag = reasonForRetag,
+        condition = SealCondition.GOOD,
+    )
 }


### PR DESCRIPTION
Update BuildObservationRecord logic and add test for retag reason inclusion

- Modified the logic in `buildObservationRecord` to append the retag reason to comments when a valid reason is selected.
- Updated the test suite to include a new test case that verifies the correct inclusion of the retag reason in the comments when applicable.