### PR TITLE
Refactor icon usage in UI components to utilize drawable resources

### DIFF
--- a/weddell-seal-android/app/build.gradle.kts
+++ b/weddell-seal-android/app/build.gradle.kts
@@ -93,7 +93,6 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
 
     implementation(libs.compose.material)
-    implementation(libs.compose.material.icons.extended)
     implementation(libs.compose.material3)
 
     implementation(libs.compose.runtime.livedata)

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/domain/files/data/FileState.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/domain/files/data/FileState.kt
@@ -1,11 +1,8 @@
 package weddellseal.markrecap.domain.files.data
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.ErrorOutline
-import androidx.compose.material.icons.filled.Pending
+import androidx.annotation.DrawableRes
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
+import weddellseal.markrecap.R
 import weddellseal.markrecap.ui.admin.FileAction
 import weddellseal.markrecap.ui.admin.FileStatus
 
@@ -27,8 +24,9 @@ fun FileStatus.color(): Color = when (this) {
     FileStatus.ERROR -> Color(0xFFD90101)
 }
 
-fun FileStatus.icon(): ImageVector = when (this) {
-    FileStatus.IDLE -> Icons.Default.Pending
-    FileStatus.SUCCESS -> Icons.Default.CheckCircle
-    FileStatus.ERROR -> Icons.Default.ErrorOutline
+@DrawableRes
+fun FileStatus.iconRes(): Int = when (this) {
+    FileStatus.IDLE -> R.drawable.ic_pending
+    FileStatus.SUCCESS -> R.drawable.ic_check_circle
+    FileStatus.ERROR -> R.drawable.ic_error_outline
 }

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/AppBar.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/AppBar.kt
@@ -2,8 +2,6 @@ package weddellseal.markrecap.ui
 
 
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -13,7 +11,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import weddellseal.markrecap.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -31,9 +31,9 @@ fun AppBar(
         navigationIcon = {
             IconButton(onClick = onNavigationIconClick) {
                 Icon(
-                    imageVector = Icons.Default.Menu,
+                    painter = painterResource(R.drawable.ic_menu),
                     contentDescription = "Toggle drawer",
-                    Modifier.size(36.dp)
+                    modifier = Modifier.size(36.dp),
                 )
             }
         },

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/CenteredAppBar.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/CenteredAppBar.kt
@@ -2,8 +2,6 @@ package weddellseal.markrecap.ui
 
 
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -13,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import weddellseal.markrecap.R
@@ -32,9 +31,9 @@ fun CenteredAppBar(
         navigationIcon = {
             IconButton(onClick = onNavigationIconClick) {
                 Icon(
-                    imageVector = Icons.Default.Menu,
+                    painter = painterResource(R.drawable.ic_menu),
                     contentDescription = "Toggle drawer",
-                    Modifier.size(36.dp)
+                    modifier = Modifier.size(36.dp),
                 )
             }
         },

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/NavMenu.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/NavMenu.kt
@@ -10,15 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AdminPanelSettings
-import androidx.compose.material.icons.filled.Checklist
-import androidx.compose.material.icons.filled.Dataset
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.PostAdd
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -32,8 +23,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import weddellseal.markrecap.R
 import weddellseal.markrecap.Screens
 
 @Composable
@@ -55,9 +48,9 @@ fun NavMenu(navController: NavHostController) {
                 selected = false,
                 icon = {
                     Icon(
-                        Icons.Default.Home,
+                        painter = painterResource(R.drawable.ic_home),
                         contentDescription = "Go to Home Screen",
-                        modifier = Modifier.size(48.dp)
+                        modifier = Modifier.size(48.dp),
                     )
                 },
                 onClick = { navController.navigate(Screens.Home.route) }
@@ -79,9 +72,9 @@ fun NavMenu(navController: NavHostController) {
                 selected = false,
                 icon = {
                     Icon(
-                        Icons.Default.Search,
+                        painter = painterResource(R.drawable.ic_search),
                         contentDescription = "Go to Seal Lookup Screen",
-                        modifier = Modifier.size(36.dp)
+                        modifier = Modifier.size(36.dp),
                     )
                 },
                 onClick = { navController.navigate(Screens.SealLookupScreen.route) }
@@ -100,7 +93,7 @@ fun NavMenu(navController: NavHostController) {
                 selected = false,
                 icon = {
                     Icon(
-                        Icons.Default.PostAdd,
+                        painter = painterResource(R.drawable.ic_post_add),
                         contentDescription = "Go to Tag/Retag Screen",
                         modifier = Modifier.size(36.dp)
                     )
@@ -120,7 +113,7 @@ fun NavMenu(navController: NavHostController) {
                 selected = false,
                 icon = {
                     Icon(
-                        Icons.Default.Checklist,
+                        painter = painterResource(R.drawable.ic_checklist),
                         contentDescription = "Enter Census Mode",
                         modifier = Modifier.size(36.dp)
                     )
@@ -142,7 +135,7 @@ fun NavMenu(navController: NavHostController) {
                 selected = false,
                 icon = {
                     Icon(
-                        Icons.Default.Dataset,
+                        painter = painterResource(R.drawable.ic_dataset),
                         contentDescription = "Go to Recent Observations Screen",
                         modifier = Modifier.size(36.dp)
                     )
@@ -151,24 +144,6 @@ fun NavMenu(navController: NavHostController) {
             )
 
             Spacer(Modifier.height(24.dp))
-
-//            NavigationDrawerItem(
-//                label = {
-//                    Text(
-//                        "Seal Lookup", style = MaterialTheme.typography.displaySmall,
-//                        modifier = Modifier.padding(start = 8.dp)
-//                    )
-//                },
-//                selected = false,
-//                icon = {
-//                    Icon(
-//                        Icons.Default.Search,
-//                        contentDescription = "Go to Seal Lookup Screen",
-//                        modifier = Modifier.size(36.dp)
-//                    )
-//                },
-//                onClick = { navController.navigate(Screens.SealLookupScreen.route) }
-//            )
 
             Spacer(Modifier.height(32.dp))
 
@@ -187,7 +162,9 @@ fun NavMenu(navController: NavHostController) {
                     style = MaterialTheme.typography.titleLarge
                 )
                 Icon(
-                    imageVector = if (adminExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                    painter = painterResource(
+                        if (adminExpanded) R.drawable.ic_arrow_drop_up else R.drawable.ic_arrow_drop_down,
+                    ),
                     contentDescription = if (adminExpanded) "Collapse" else "Expand"
                 )
             }
@@ -204,7 +181,7 @@ fun NavMenu(navController: NavHostController) {
                     selected = false,
                     icon = {
                         Icon(
-                            Icons.Default.AdminPanelSettings,
+                            painter = painterResource(R.drawable.ic_admin_panel_settings),
                             contentDescription = null,
                             modifier = Modifier.size(36.dp)
                         )

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/ObservationItem.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/ObservationItem.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -48,9 +46,9 @@ fun ObservationItem(
         Box(modifier = Modifier.padding(start = 10.dp, end = 10.dp)) {
             IconButton(onClick = { expanded = true }) {
                 Icon(
-                    imageVector = Icons.Default.MoreVert, // Three-dot icon
+                    painter = painterResource(R.drawable.ic_more_vert),
                     contentDescription = "More options",
-                    Modifier.size(36.dp)
+                    modifier = Modifier.size(36.dp),
                 )
             }
 

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/AdminScreen.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/AdminScreen.kt
@@ -10,17 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Archive
-import androidx.compose.material.icons.filled.Dashboard
-import androidx.compose.material.icons.filled.FileDownload
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.outlined.Archive
-import androidx.compose.material.icons.outlined.Dashboard
-import androidx.compose.material.icons.outlined.FileDownload
-import androidx.compose.material.icons.outlined.Home
-import androidx.compose.material.icons.outlined.UploadFile
-import androidx.compose.material.icons.sharp.UploadFile
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationRail
@@ -64,21 +53,20 @@ fun AdminScreen(
 
     val items =
         listOf("Home", "Dashboard", "Import", "Export", "Archive")
-    val selectedIcons = listOf(
-        Icons.Default.Home,
-        Icons.Default.Dashboard,
-        Icons.Sharp.UploadFile,
-        Icons.Default.FileDownload,
-        Icons.Default.Archive
+    val selectedIconRes = listOf(
+        R.drawable.ic_home,
+        R.drawable.ic_dashboard,
+        R.drawable.ic_upload_file_filled,
+        R.drawable.ic_file_download,
+        R.drawable.ic_archive,
     )
-    val unselectedIcons =
-        listOf(
-            Icons.Outlined.Home,
-            Icons.Outlined.Dashboard,
-            Icons.Outlined.UploadFile,
-            Icons.Outlined.FileDownload,
-            Icons.Outlined.Archive
-        )
+    val unselectedIconRes = listOf(
+        R.drawable.ic_home_outlined,
+        R.drawable.ic_dashboard_outlined,
+        R.drawable.ic_upload_file_outlined,
+        R.drawable.ic_file_download_outlined,
+        R.drawable.ic_archive_outlined,
+    )
 
     Scaffold { innerPadding ->
         Row(
@@ -94,9 +82,12 @@ fun AdminScreen(
                     NavigationRailItem(
                         icon = {
                             Icon(
-                                if (selectedItem == index) selectedIcons[index] else unselectedIcons[index],
+                                painter = painterResource(
+                                    if (selectedItem == index) selectedIconRes[index]
+                                    else unselectedIconRes[index],
+                                ),
                                 contentDescription = item,
-                                modifier = Modifier.size(48.dp)
+                                modifier = Modifier.size(48.dp),
                             )
                         },
                         label = {

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/dashboard/FileImportItem.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/dashboard/FileImportItem.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.UploadFile
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -14,7 +12,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import weddellseal.markrecap.R
 import weddellseal.markrecap.frameworks.room.files.FileUploadEntity
 import weddellseal.markrecap.ui.utils.formatFileUploadedDateTime
 
@@ -33,7 +33,7 @@ fun FileImportItem(successfulUpload: FileUploadEntity) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
-                imageVector = Icons.Default.UploadFile,
+                painter = painterResource(R.drawable.ic_upload_file_outlined),
                 contentDescription = null,
                 tint = Color.Black,
                 modifier = Modifier

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/dashboard/LastFilesImportedCard.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/dashboard/LastFilesImportedCard.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.History
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -18,7 +16,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import weddellseal.markrecap.R
 import weddellseal.markrecap.frameworks.room.files.FileUploadEntity
 
 @Composable
@@ -47,7 +47,7 @@ fun LastFilesImportedCard(
                             horizontalArrangement = Arrangement.Center
                 ) {
                     Icon(
-                        imageVector = Icons.Default.History,
+                        painter = painterResource(R.drawable.ic_history),
                         contentDescription = null,
                         modifier = Modifier
                             .size(48.dp)

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/export/ExportAllObservationsCard.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/export/ExportAllObservationsCard.kt
@@ -10,9 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FileDownload
-import androidx.compose.material.icons.filled.Pending
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -23,17 +20,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import weddellseal.markrecap.R
 import weddellseal.markrecap.domain.files.data.FileState
 import weddellseal.markrecap.domain.files.data.color
-import weddellseal.markrecap.domain.files.data.icon
+import weddellseal.markrecap.domain.files.data.iconRes
 import weddellseal.markrecap.ui.admin.FileStatus
 import weddellseal.markrecap.ui.recentobservations.RecentObservationsViewModel
 
@@ -48,13 +48,13 @@ fun ExportAllObservationsCard(
     var errMessage by remember { mutableStateOf("") }
     var exportedFilename by remember { mutableStateOf("") }
     var statusColor by remember { mutableStateOf(Color(0xFF5884fa)) }
-    var statusIcon by remember { mutableStateOf(Icons.Default.Pending) }
+    var statusIcon by remember { mutableIntStateOf(R.drawable.ic_pending) }
 
     LaunchedEffect(state) {
         errMessage = state.message.toString()
         exportedFilename = state.exportFilename.toString()
         statusColor = state.status.color()
-        statusIcon = state.status.icon()
+        statusIcon = state.status.iconRes()
     }
 
     Card(
@@ -99,7 +99,7 @@ fun ExportAllObservationsCard(
                 enabled = allObservationsCount > 0
             ) {
                 Icon(
-                    imageVector = Icons.Default.FileDownload,
+                    painter = painterResource(R.drawable.ic_file_download),
                     contentDescription = null,
                     tint = Color.White,
                     modifier = Modifier
@@ -122,7 +122,7 @@ fun ExportAllObservationsCard(
                     horizontalArrangement = Arrangement.Center
                 ) {
                     Icon(
-                        imageVector = statusIcon,
+                        painter = painterResource(statusIcon),
                         contentDescription = null,
                         tint = statusColor,
                         modifier = Modifier

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/export/ExportCurrentObservationsCard.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/export/ExportCurrentObservationsCard.kt
@@ -13,9 +13,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FileDownload
-import androidx.compose.material.icons.filled.Pending
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -26,17 +23,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import weddellseal.markrecap.R
 import weddellseal.markrecap.domain.files.data.FileState
 import weddellseal.markrecap.domain.files.data.color
-import weddellseal.markrecap.domain.files.data.icon
+import weddellseal.markrecap.domain.files.data.iconRes
 import weddellseal.markrecap.ui.admin.FileStatus
 import weddellseal.markrecap.ui.recentobservations.RecentObservationsViewModel
 
@@ -50,13 +50,13 @@ fun ExportCurrentObservationsCard(
     var errMessage by remember { mutableStateOf("") }
     var exportedFilename by remember { mutableStateOf("") }
     var statusColor by remember { mutableStateOf(Color(0xFF5884fa)) }
-    var statusIcon by remember { mutableStateOf(Icons.Default.Pending) }
+    var statusIcon by remember { mutableIntStateOf(R.drawable.ic_pending) }
 
     LaunchedEffect(state) {
         errMessage = state.message.toString()
         exportedFilename = state.exportFilename.toString()
         statusColor = state.status.color()
-        statusIcon = state.status.icon()
+        statusIcon = state.status.iconRes()
     }
 
     Card(
@@ -89,7 +89,7 @@ fun ExportCurrentObservationsCard(
                 enabled = currentObservationsCount > 0
             ) {
                 Icon(
-                    imageVector = Icons.Default.FileDownload,
+                    painter = painterResource(R.drawable.ic_file_download),
                     contentDescription = null,
                     tint = Color.White,
                     modifier = Modifier
@@ -112,7 +112,7 @@ fun ExportCurrentObservationsCard(
                     horizontalArrangement = Arrangement.Center
                 ) {
                     Icon(
-                        imageVector = statusIcon,
+                        painter = painterResource(statusIcon),
                         contentDescription = null,
                         tint = statusColor,
                         modifier = Modifier

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/export/FileExportErrorExplanationDialog.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/export/FileExportErrorExplanationDialog.kt
@@ -3,8 +3,6 @@ package weddellseal.markrecap.ui.admin.export
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -13,7 +11,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import weddellseal.markrecap.R
 
 @Composable
 fun FileExportErrorExplanationDialog(
@@ -37,7 +37,7 @@ fun FileExportErrorExplanationDialog(
         },
         icon = {
             Icon(
-                Icons.Default.ErrorOutline,
+                painter = painterResource(R.drawable.ic_error_outline),
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.surfaceTint,
                 modifier = Modifier.size(48.dp)

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/import/FileImportCard.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/import/FileImportCard.kt
@@ -10,9 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Pending
-import androidx.compose.material.icons.filled.UploadFile
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -22,16 +19,19 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import weddellseal.markrecap.R
 import weddellseal.markrecap.domain.files.data.FileState
 import weddellseal.markrecap.domain.files.data.color
-import weddellseal.markrecap.domain.files.data.icon
+import weddellseal.markrecap.domain.files.data.iconRes
 import weddellseal.markrecap.ui.admin.FileStatus
 
 @Composable
@@ -41,13 +41,13 @@ fun ImportCard(
     var errMessage by remember { mutableStateOf("") }
     var lastFilename by remember { mutableStateOf("") }
     var statusColor by remember { mutableStateOf(Color(0xFF5884fa)) }
-    var statusIcon by remember { mutableStateOf(Icons.Default.Pending) }
+    var statusIcon by remember { mutableIntStateOf(R.drawable.ic_pending) }
 
     LaunchedEffect(state.status) {
         errMessage = state.message.toString()
         lastFilename = state.lastUploadFilename.toString()
         statusColor = state.status.color()
-        statusIcon = state.status.icon()
+        statusIcon = state.status.iconRes()
     }
 
     Card(
@@ -73,7 +73,7 @@ fun ImportCard(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Icon(
-                        imageVector = Icons.Default.UploadFile,
+                        painter = painterResource(R.drawable.ic_upload_file_outlined),
                         contentDescription = null,
                         tint = Color.Black,
                         modifier = Modifier
@@ -105,7 +105,7 @@ fun ImportCard(
                     horizontalArrangement = Arrangement.Center
                 ) {
                     Icon(
-                        imageVector = statusIcon,
+                        painter = painterResource(statusIcon),
                         contentDescription = null,
                         tint = statusColor,
                         modifier = Modifier

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/import/FileImportErrorExplanationDialog.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/admin/import/FileImportErrorExplanationDialog.kt
@@ -3,8 +3,6 @@ package weddellseal.markrecap.ui.admin.import
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -13,7 +11,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import weddellseal.markrecap.R
 
 @Composable
 fun FileImportErrorExplanationDialog(
@@ -37,7 +37,7 @@ fun FileImportErrorExplanationDialog(
         },
         icon = {
             Icon(
-                Icons.Default.ErrorOutline,
+                painter = painterResource(R.drawable.ic_error_outline),
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.surfaceTint,
                 modifier = Modifier.size(48.dp)

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/census/CensusDropDown.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/census/CensusDropDown.kt
@@ -3,8 +3,6 @@ package weddellseal.markrecap.ui.census
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -22,6 +20,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import weddellseal.markrecap.R
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
@@ -60,9 +60,9 @@ fun CensusDropDown(
                             focusManager.clearFocus()  // collapses label
                         }) {
                         Icon(
-                            Icons.Default.Close,
+                            painter = painterResource(R.drawable.ic_clear),
                             contentDescription = "Clear selection",
-                            modifier = Modifier.size(36.dp)
+                            modifier = Modifier.size(36.dp),
                         )
                     }
                 } else {

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/home/CoordinatesTextField.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/home/CoordinatesTextField.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -19,6 +17,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import weddellseal.markrecap.R
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
@@ -75,11 +75,12 @@ fun CoordinatesTextField(
         trailingIcon = {
             if (text.isNotEmpty()) {
                 Icon(
-                    Icons.Filled.Clear, contentDescription = "Clear text",
-                    Modifier.clickable {
+                    painter = painterResource(R.drawable.ic_clear),
+                    contentDescription = "Clear text",
+                    modifier = Modifier.clickable {
                         text = ""
                         onClearValueDo()
-                    }
+                    },
                 )
             }
         },

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/home/DeviceGPSRow.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/home/DeviceGPSRow.kt
@@ -9,9 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.LocationOff
-import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -22,7 +19,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import weddellseal.markrecap.R
 import weddellseal.markrecap.domain.location.data.toLocationString
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -49,7 +48,7 @@ fun DeviceGPSRow(
         Column {
             if (location?.coordinates?.longitude != null && location?.coordinates?.latitude != null) {
                 Icon(
-                    Icons.Filled.LocationOn,
+                    painter = painterResource(R.drawable.ic_location_on),
                     contentDescription = null,
                     tint = Color(0xFF1D9C06),
                     modifier = Modifier
@@ -58,7 +57,7 @@ fun DeviceGPSRow(
                 )
             } else {
                 Icon(
-                    Icons.Filled.LocationOff,
+                    painter = painterResource(R.drawable.ic_location_off),
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.error.copy(alpha = 0.9f),
                     modifier = Modifier

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/home/MultiSelectDropdownObservers.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/home/MultiSelectDropdownObservers.kt
@@ -3,12 +3,11 @@ package weddellseal.markrecap.ui.home
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import weddellseal.markrecap.R
 
 data class SelectableItem(val title: String, var isSelected: Boolean = false)
 
@@ -63,8 +62,10 @@ fun MultiSelectDropdownObservers(
                 trailingIcon = {
                     IconButton(onClick = { expanded = !expanded }) {
                         Icon(
-                            imageVector = if (expanded) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown,
-                            contentDescription = null
+                            painter = painterResource(
+                                if (expanded) R.drawable.ic_arrow_drop_up else R.drawable.ic_arrow_drop_down,
+                            ),
+                            contentDescription = null,
                         )
                     }
                 },

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/lookup/SealLookupScreen.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/lookup/SealLookupScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.PostAdd
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DrawerValue
@@ -35,7 +33,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import weddellseal.markrecap.R
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.launch
 import weddellseal.markrecap.Screens
@@ -142,9 +142,9 @@ fun SealLookupScreen(
                                     },
                                     icon = {
                                         Icon(
-                                            Icons.Filled.PostAdd,
-                                            "Edit seal",
-                                            Modifier.size(36.dp),
+                                            painter = painterResource(R.drawable.ic_post_add),
+                                            contentDescription = "Edit seal",
+                                            modifier = Modifier.size(36.dp),
                                             tint = MaterialTheme.colorScheme.onSecondary,
                                         )
                                     },

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/lookup/SealSearchField.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/lookup/SealSearchField.kt
@@ -6,9 +6,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
@@ -21,6 +18,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import weddellseal.markrecap.R
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
@@ -97,14 +96,15 @@ fun SealSearchField(
         trailingIcon = {
             if (searchString.isNotEmpty()) {
                 Icon(
-                    Icons.Filled.Clear, contentDescription = "Clear text",
-                    Modifier
+                    painter = painterResource(R.drawable.ic_clear),
+                    contentDescription = "Clear text",
+                    modifier = Modifier
                         .clickable {
                             searchString = ""
                             viewModel.resetLookupUiState()
                             viewModel.resetLookupSeal()
                         }
-                        .size(35.dp) // Adjust the size as needed
+                        .size(35.dp),
                 )
             }
         },
@@ -132,9 +132,9 @@ fun SealSearchField(
             modifier = Modifier.padding(bottom = 15.dp, end = 20.dp),
         ) {
             Icon(
-                imageVector = Icons.Default.Search,
+                painter = painterResource(R.drawable.ic_search),
                 contentDescription = "Search",
-                modifier = Modifier.size(45.dp)
+                modifier = Modifier.size(45.dp),
             )
         }
     }

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/permissions/LocationPermissionsView.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/permissions/LocationPermissionsView.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -20,6 +18,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import weddellseal.markrecap.R
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -46,9 +46,9 @@ fun LocationPermissionView(
         Spacer(modifier = Modifier.weight(1.0f))
 
         Icon(
-            Icons.Filled.LocationOn,
+            painter = painterResource(R.drawable.ic_location_on),
             contentDescription = "permission icon",
-            modifier = Modifier.size(100.dp)
+            modifier = Modifier.size(100.dp),
         )
 
         Text(text = "Enable Location", style = MaterialTheme.typography.headlineLarge)

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/recentobservations/ObservationViewer.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/recentobservations/ObservationViewer.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBackIosNew
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -16,9 +14,11 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
+import weddellseal.markrecap.R
 import weddellseal.markrecap.ui.tagretag.TagRetagViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -47,7 +47,7 @@ fun ObservationViewer(
                         navController.navigateUp()
                     }) {
                         Icon(
-                            imageVector = Icons.Filled.ArrowBackIosNew,
+                            painter = painterResource(R.drawable.ic_arrow_back_ios_new),
                             contentDescription = "Back",
                             modifier = Modifier.size(48.dp)
                         )

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/CommentField.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/CommentField.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -22,6 +20,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import weddellseal.markrecap.R
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalFocusManager
@@ -91,11 +91,12 @@ fun CommentField(
         trailingIcon = {
             if (value.isNotEmpty()) {
                 Icon(
-                    Icons.Filled.Clear, contentDescription = "Clear text",
-                    Modifier.clickable {
+                    painter = painterResource(R.drawable.ic_clear),
+                    contentDescription = "Clear text",
+                    modifier = Modifier.clickable {
                         text = ""
                         onClearValueDo()
-                    }
+                    },
                 )
             }
         },

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/ConditionSegmentedButtonGroup.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/ConditionSegmentedButtonGroup.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -18,7 +16,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import weddellseal.markrecap.R
 import weddellseal.markrecap.domain.tagretag.data.SealCondition
 
 private val CONDITION_OPTIONS = SealCondition.values()
@@ -81,7 +81,7 @@ fun ConditionSegmentedButtonGroup(
                 ) {
                     if (isSelected) {
                         Icon(
-                            imageVector = Icons.Default.Check,
+                            painter = painterResource(R.drawable.ic_check),
                             contentDescription = "Selected",
                             tint = Color.White,
                         )

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/PupWeightOutlinedTextField.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/PupWeightOutlinedTextField.kt
@@ -3,8 +3,6 @@ package weddellseal.markrecap.ui.tagretag
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -17,6 +15,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import weddellseal.markrecap.R
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
@@ -72,11 +72,12 @@ fun PupWeightOutlinedTextField(
         trailingIcon = {
             if (text.isNotEmpty()) {
                 Icon(
-                    Icons.Filled.Clear, contentDescription = "Clear text",
-                    Modifier.clickable {
+                    painter = painterResource(R.drawable.ic_clear),
+                    contentDescription = "Clear text",
+                    modifier = Modifier.clickable {
                         text = ""
                         onClearValueDo()
-                    }
+                    },
                 )
             }
         },

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/SegmentedButtonGroup.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/SegmentedButtonGroup.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -15,6 +13,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import weddellseal.markrecap.R
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 
@@ -66,10 +66,10 @@ fun SegmentedButtonGroup(
                 ) {
                     if (isSelected) {
                         Icon(
-                            imageVector = Icons.Default.Check,
+                            painter = painterResource(R.drawable.ic_check),
                             contentDescription = "Selected",
                             tint = Color.White,
-                            modifier = Modifier.padding(end = 4.dp)
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                     Text(text = option, style = MaterialTheme.typography.headlineSmall)

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/TabbedCards.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/TabbedCards.kt
@@ -13,10 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.DeleteOutline
-import androidx.compose.material.icons.filled.Error
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -38,9 +34,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import weddellseal.markrecap.R
 import weddellseal.markrecap.domain.tagretag.data.Seal
 import weddellseal.markrecap.domain.tagretag.data.SealType
 import weddellseal.markrecap.domain.tagretag.data.TagEventType
@@ -115,13 +113,13 @@ fun TabbedCards(
                             if (uiState.isSaveAttempted) {
                                 val iconColor =
                                     if (tabItem.seal.isValid) Color(0xFF4CAF50) else MaterialTheme.colorScheme.error
-                                val icon =
-                                    if (tabItem.seal.isValid) Icons.Default.Check else Icons.Default.Error
                                 Icon(
-                                    imageVector = icon,
+                                    painter = painterResource(
+                                        if (tabItem.seal.isValid) R.drawable.ic_check else R.drawable.ic_error_outline,
+                                    ),
                                     contentDescription = "Seal Valid",
                                     tint = iconColor,
-                                    modifier = Modifier.size(32.dp)
+                                    modifier = Modifier.size(32.dp),
                                 )
                             }
                         }
@@ -226,7 +224,7 @@ fun TabbedCards(
                             onClick = { showDeleteDialog.value = true },
                         ) {
                             Icon(
-                                imageVector = Icons.Default.DeleteOutline,
+                                painter = painterResource(R.drawable.ic_delete_outline),
                                 contentDescription = "Remove Tab",
                                 tint = MaterialTheme.colorScheme.onSurface,
                                 modifier = Modifier.size(48.dp),

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagIDOutlinedTextField.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagIDOutlinedTextField.kt
@@ -3,8 +3,6 @@ package weddellseal.markrecap.ui.tagretag
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -17,6 +15,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import weddellseal.markrecap.R
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
@@ -83,11 +83,12 @@ fun TagIDOutlinedTextField(
         trailingIcon = {
             if (text.isNotEmpty()) {
                 Icon(
-                    Icons.Filled.Clear, contentDescription = "Clear text",
-                    Modifier.clickable {
+                    painter = painterResource(R.drawable.ic_clear),
+                    contentDescription = "Clear text",
+                    modifier = Modifier.clickable {
                         text = ""
                         onClearValueDo()
-                    }
+                    },
                 )
             }
         },

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagRetagAppBar.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagRetagAppBar.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -23,7 +21,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
+import weddellseal.markrecap.R
 import androidx.compose.ui.unit.dp
 import weddellseal.markrecap.frameworks.room.sealColonies.SealColony
 import weddellseal.markrecap.ui.home.HomeViewModel
@@ -100,9 +100,9 @@ fun TagRetagAppBar(
         navigationIcon = {
             IconButton(onClick = onNavigationIconClick) {
                 Icon(
-                    imageVector = Icons.Default.Menu,
+                    painter = painterResource(R.drawable.ic_menu),
                     contentDescription = "Toggle drawer",
-                    Modifier.size(36.dp)
+                    modifier = Modifier.size(36.dp),
                 )
             }
         },

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagRetagFooter.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagRetagFooter.kt
@@ -14,11 +14,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Error
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExtendedFloatingActionButton
@@ -38,8 +33,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import weddellseal.markrecap.R
 import weddellseal.markrecap.Screens
 import weddellseal.markrecap.ui.ConfirmEditDialog
 import weddellseal.markrecap.ui.RecentObservations
@@ -126,9 +123,9 @@ fun TagRetagFooter(
                     },
                     icon = {
                         Icon(
-                            Icons.Filled.Save,
-                            "Save Seal",
-                            Modifier.size(36.dp),
+                            painter = painterResource(R.drawable.ic_save),
+                            contentDescription = "Save Seal",
+                            modifier = Modifier.size(36.dp),
                             tint = if (!uiState.isSaveEnabled || uiState.entryNeedsConfirmation) MaterialTheme.colorScheme.surface else MaterialTheme.colorScheme.onSecondary,
                         )
                     },
@@ -159,9 +156,9 @@ fun TagRetagFooter(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Icon(
-                        imageVector = Icons.Filled.Error,
+                        painter = painterResource(R.drawable.ic_error_outline),
                         contentDescription = "Error",
-                        tint = MaterialTheme.colorScheme.error
+                        tint = MaterialTheme.colorScheme.error,
                     )
                     Text(
                         modifier = Modifier.padding(start = 8.dp),
@@ -177,10 +174,12 @@ fun TagRetagFooter(
                     ) {
                         IconButton(onClick = { expanded = true }) {
                             Icon(
-                                imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                                painter = painterResource(
+                                    if (expanded) R.drawable.ic_arrow_drop_up else R.drawable.ic_arrow_drop_down,
+                                ),
                                 contentDescription = "Expand error details",
                                 tint = Color.Red,
-                                modifier = Modifier.size(36.dp)
+                                modifier = Modifier.size(36.dp),
                             )
                         }
 

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagRetagHeader.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/TagRetagHeader.kt
@@ -10,12 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Female
-import androidx.compose.material.icons.filled.Male
-import androidx.compose.material.icons.filled.Save
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material.icons.outlined.Cancel
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
@@ -84,9 +78,9 @@ fun TagRetagHeader(
             ExtendedFloatingActionButton(
                 icon = {
                     Icon(
-                        Icons.Filled.Female,
-                        "Single Female",
-                        Modifier.size(36.dp)
+                        painter = painterResource(R.drawable.ic_female),
+                        contentDescription = "Single Female",
+                        modifier = Modifier.size(36.dp),
                     )
                 },
                 text = {
@@ -109,9 +103,9 @@ fun TagRetagHeader(
             ExtendedFloatingActionButton(
                 icon = {
                     Icon(
-                        Icons.Filled.Male,
-                        "Single Male",
-                        Modifier.size(36.dp)
+                        painter = painterResource(R.drawable.ic_male),
+                        contentDescription = "Single Male",
+                        modifier = Modifier.size(36.dp),
                     )
                 },
                 text = {
@@ -209,9 +203,9 @@ fun TagRetagHeader(
                 },
                 icon = {
                     Icon(
-                        Icons.Outlined.Cancel,
-                        "Exit Edit Mode",
-                        Modifier.size(36.dp),
+                        painter = painterResource(R.drawable.ic_cancel_outlined),
+                        contentDescription = "Exit Edit Mode",
+                        modifier = Modifier.size(36.dp),
                     )
                 },
                 text = {
@@ -238,10 +232,10 @@ fun TagRetagHeader(
             horizontalArrangement = Arrangement.Center
         ) {
             Icon(
-                imageVector = Icons.Default.Warning,
+                painter = painterResource(R.drawable.ic_warning),
                 contentDescription = "Warning",
                 tint = Color(0xFFF57C00),
-                modifier = Modifier.padding(end = 8.dp)
+                modifier = Modifier.padding(end = 8.dp),
             )
             Text(
                 text = "Please review the data you've entered and confirm it is correct before saving.",
@@ -277,7 +271,13 @@ fun TagRetagHeader(
 
                     viewModel.writeObservationRecord(homeViewModel.getColonyLocation())
                 },
-                icon = { Icon(Icons.Filled.Save, "Confirm & Save", Modifier.size(36.dp)) },
+                icon = {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_save),
+                        contentDescription = "Confirm & Save",
+                        modifier = Modifier.size(36.dp),
+                    )
+                },
                 text = {
                     Text(
                         text = "Confirm & Save",
@@ -297,7 +297,9 @@ fun TagRetagHeader(
                 },
                 icon = {
                     Icon(
-                        Icons.Filled.Save, "Edit", Modifier.size(36.dp)
+                        painter = painterResource(R.drawable.ic_save),
+                        contentDescription = "Edit",
+                        modifier = Modifier.size(36.dp),
                     )
                 },
                 text = {

--- a/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/dialogs/LocationExplanationDialog.kt
+++ b/weddell-seal-android/app/src/main/java/weddellseal/markrecap/ui/tagretag/dialogs/LocationExplanationDialog.kt
@@ -1,7 +1,5 @@
 package weddellseal.markrecap.ui.tagretag.dialogs
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
@@ -9,6 +7,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.painterResource
+import weddellseal.markrecap.R
 
 @Composable
 fun LocationExplanationDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
@@ -18,7 +18,7 @@ fun LocationExplanationDialog(onConfirm: () -> Unit, onDismiss: () -> Unit) {
         text = { Text("Weddell Seal Mark Recap app would like access to your location to save it when creating a log") },
         icon = {
             Icon(
-                Icons.Filled.Explore,
+                painter = painterResource(R.drawable.ic_explore),
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.surfaceTint
             )

--- a/weddell-seal-android/app/src/main/res/drawable/ic_admin_panel_settings.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_admin_panel_settings.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 17 11 c 0.34 0 0.67 0.04 1 0.09 V 6.27 L 10.5 3 L 3 6.27 v 4.91 c 0 4.54 3.2 8.79 7.5 9.82 c 0.55 -0.13 1.08 -0.32 1.6 -0.55 C 11.41 19.47 11 18.28 11 17 C 11 13.69 13.69 11 17 11 Z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 17 13 c -2.21 0 -4 1.79 -4 4 c 0 2.21 1.79 4 4 4 s 4 -1.79 4 -4 C 21 14.79 19.21 13 17 13 Z M 17 14.38 c 0.62 0 1.12 0.51 1.12 1.12 s -0.51 1.12 -1.12 1.12 s -1.12 -0.51 -1.12 -1.12 S 16.38 14.38 17 14.38 Z M 17 19.75 c -0.93 0 -1.74 -0.46 -2.24 -1.17 c 0.05 -0.72 1.51 -1.08 2.24 -1.08 s 2.19 0.36 2.24 1.08 C 18.74 19.29 17.93 19.75 17 19.75 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_archive.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_archive.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 20.54 5.23 l -1.39 -1.68 C 18.88 3.21 18.47 3 18 3 H 6 c -0.47 0 -0.88 0.21 -1.16 0.55 L 3.46 5.23 C 3.17 5.57 3 6.02 3 6.5 V 19 c 0 1.1 0.9 2 2 2 h 14 c 1.1 0 2 -0.9 2 -2 V 6.5 c 0 -0.48 -0.17 -0.93 -0.46 -1.27 Z M 12 17.5 L 6.5 12 H 10 v -2 h 4 v 2 h 3.5 L 12 17.5 Z M 5.12 5 l 0.81 -1 h 12 l 0.94 1 H 5.12 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_archive_outlined.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_archive_outlined.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 20.54 5.23 l -1.39 -1.68 C 18.88 3.21 18.47 3 18 3 L 6 3 c -0.47 0 -0.88 0.21 -1.16 0.55 L 3.46 5.23 C 3.17 5.57 3 6.02 3 6.5 L 3 19 c 0 1.1 0.9 2 2 2 h 14 c 1.1 0 2 -0.9 2 -2 L 21 6.5 c 0 -0.48 -0.17 -0.93 -0.46 -1.27 Z M 6.24 5 h 11.52 l 0.81 0.97 L 5.44 5.97 l 0.8 -0.97 Z M 5 19 L 5 8 h 14 v 11 L 5 19 Z M 13.45 10 h -2.9 v 3 L 8 13 l 4 4 l 4 -4 h -2.55 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_arrow_back_ios_new.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_arrow_back_ios_new.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 17.77 3.77 l -1.77 -1.77 l -10 10 l 10 10 l 1.77 -1.77 l -8.23 -8.23 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_arrow_drop_down.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_arrow_drop_down.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 7 10 l 5 5 5 -5 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_arrow_drop_up.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_arrow_drop_up.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 7 14 l 5 -5 5 5 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_cancel_outlined.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_cancel_outlined.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 12 2 C 6.47 2 2 6.47 2 12 s 4.47 10 10 10 s 10 -4.47 10 -10 S 17.53 2 12 2 Z M 12 20 c -4.41 0 -8 -3.59 -8 -8 s 3.59 -8 8 -8 s 8 3.59 8 8 s -3.59 8 -8 8 Z M 15.59 7 L 12 10.59 L 8.41 7 L 7 8.41 L 10.59 12 L 7 15.59 L 8.41 17 L 12 13.41 L 15.59 17 L 17 15.59 L 13.41 12 L 17 8.41 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_check.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 9 16.17 L 4.83 12 l -1.42 1.41 L 9 19 L 21 7 l -1.41 -1.41 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_check_circle.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_check_circle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="m424,664 l282,-282 -56,-56 -226,226 -114,-114 -56,56 170,170ZM480,880q-83,0 -156,-31.5T197,763q-54,-54 -85.5,-127T80,480q0,-83 31.5,-156T197,197q54,-54 127,-85.5T480,80q83,0 156,31.5T763,197q54,54 85.5,127T880,480q0,83 -31.5,156T763,763q-54,54 -127,85.5T480,880Z"
+      android:fillColor="#1f1f1f"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_checklist.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_checklist.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 22 7 h -9 v 2 h 9 V 7 Z M 22 15 h -9 v 2 h 9 V 15 Z M 5.54 11 L 2 7.46 l 1.41 -1.41 l 2.12 2.12 l 4.24 -4.24 l 1.41 1.41 L 5.54 11 Z M 5.54 19 L 2 15.46 l 1.41 -1.41 l 2.12 2.12 l 4.24 -4.24 l 1.41 1.41 L 5.54 19 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_clear.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_clear.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 19 6.41 L 17.59 5 L 12 10.59 L 6.41 5 L 5 6.41 L 10.59 12 L 5 17.59 L 6.41 19 L 12 13.41 L 17.59 19 L 19 17.59 L 13.41 12 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_dashboard.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_dashboard.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 3 13 h 8 L 11 3 L 3 3 v 10 Z M 3 21 h 8 v -6 L 3 15 v 6 Z M 13 21 h 8 L 21 11 h -8 v 10 Z M 13 3 v 6 h 8 L 21 3 h -8 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_dashboard_outlined.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_dashboard_outlined.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 19 5 v 2 h -4 L 15 5 h 4 M 9 5 v 6 L 5 11 L 5 5 h 4 v 6 h -4 v -6 h 4 M 9 17 v 2 L 5 19 v -2 h 4 M 21 3 h -8 v 6 h 8 L 21 3 Z M 11 3 L 3 3 v 10 h 8 L 11 3 Z M 21 11 h -8 v 10 h 8 L 21 11 Z M 11 15 L 3 15 v 6 h 8 v -6 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_dataset.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_dataset.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 19 3 H 5 C 3.9 3 3 3.9 3 5 v 14 c 0 1.1 0.9 2 2 2 h 14 c 1.1 0 2 -0.9 2 -2 V 5 C 21 3.9 20.1 3 19 3 Z M 11 17 H 7 v -4 h 4 V 17 Z M 11 11 H 7 V 7 h 4 V 11 Z M 17 17 h -4 v -4 h 4 V 17 Z M 17 11 h -4 V 7 h 4 V 11 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_delete_outline.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_delete_outline.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 6 19 c 0 1.1 0.9 2 2 2 h 8 c 1.1 0 2 -0.9 2 -2 L 18 7 L 6 7 v 12 Z M 8 9 h 8 v 10 L 8 19 L 8 9 Z M 15.5 4 l -1 -1 h -5 l -1 1 L 5 4 v 2 h 14 L 19 4 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_error_outline.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_error_outline.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 11 15 h 2 v 2 h -2 Z M 11 7 h 2 v 6 h -2 Z M 11.99 2 C 6.47 2 2 6.48 2 12 s 4.47 10 9.99 10 C 17.52 22 22 17.52 22 12 S 17.52 2 11.99 2 Z M 12 20 c -4.42 0 -8 -3.58 -8 -8 s 3.58 -8 8 -8 s 8 3.58 8 8 s -3.58 8 -8 8 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_explore.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_explore.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 12 10.9 c -0.61 0 -1.1 0.49 -1.1 1.1 s 0.49 1.1 1.1 1.1 c 0.61 0 1.1 -0.49 1.1 -1.1 s -0.49 -1.1 -1.1 -1.1 Z M 12 2 C 6.48 2 2 6.48 2 12 s 4.48 10 10 10 s 10 -4.48 10 -10 S 17.52 2 12 2 Z M 14.19 14.19 L 6 18 l 3.81 -8.19 L 18 6 l -3.81 8.19 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_female.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_female.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 17.5 9.5 C 17.5 6.46 15.04 4 12 4 S 6.5 6.46 6.5 9.5 c 0 2.7 1.94 4.93 4.5 5.4 V 17 H 9 v 2 h 2 v 2 h 2 v -2 h 2 v -2 h -2 v -2.1 C 15.56 14.43 17.5 12.2 17.5 9.5 Z M 8.5 9.5 C 8.5 7.57 10.07 6 12 6 s 3.5 1.57 3.5 3.5 S 13.93 13 12 13 S 8.5 11.43 8.5 9.5 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_file_download.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_file_download.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 19 9 h -4 V 3 H 9 v 6 H 5 l 7 7 l 7 -7 Z M 5 18 v 2 h 14 v -2 H 5 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_file_download_outlined.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_file_download_outlined.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 18 15 v 3 H 6 v -3 H 4 v 3 c 0 1.1 0.9 2 2 2 h 12 c 1.1 0 2 -0.9 2 -2 v -3 H 18 Z M 17 11 l -1.41 -1.41 L 13 12.17 V 4 h -2 v 8.17 L 8.41 9.59 L 7 11 l 5 5 L 17 11 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_history.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_history.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 13 3 c -4.97 0 -9 4.03 -9 9 L 1 12 l 3.89 3.89 l 0.07 0.14 L 9 12 L 6 12 c 0 -3.87 3.13 -7 7 -7 s 7 3.13 7 7 s -3.13 7 -7 7 c -1.93 0 -3.68 -0.79 -4.94 -2.06 l -1.42 1.42 C 8.27 19.99 10.51 21 13 21 c 4.97 0 9 -4.03 9 -9 s -4.03 -9 -9 -9 Z M 12 8 v 5 l 4.28 2.54 l 0.72 -1.21 l -3.5 -2.08 L 13.5 8 L 12 8 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_home.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_home.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 10 20 v -6 h 4 v 6 h 5 v -8 h 3 L 12 3 L 2 12 h 3 v 8 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_home_outlined.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_home_outlined.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 12 5.69 l 5 4.5 V 18 h -2 v -6 H 9 v 6 H 7 v -7.81 l 5 -4.5 M 12 3 L 2 12 h 3 v 8 h 6 v -6 h 2 v 6 h 6 v -8 h 3 L 12 3 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_location_off.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_location_off.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 12 6.5 c 1.38 0 2.5 1.12 2.5 2.5 c 0 0.74 -0.33 1.39 -0.83 1.85 l 3.63 3.63 c 0.98 -1.86 1.7 -3.8 1.7 -5.48 c 0 -3.87 -3.13 -7 -7 -7 c -1.98 0 -3.76 0.83 -5.04 2.15 l 3.19 3.19 c 0.46 -0.52 1.11 -0.84 1.85 -0.84 Z M 16.37 16.1 l -4.63 -4.63 l -0.11 -0.11 L 3.27 3 L 2 4.27 l 3.18 3.18 C 5.07 7.95 5 8.47 5 9 c 0 5.25 7 13 7 13 s 1.67 -1.85 3.38 -4.35 L 18.73 21 L 20 19.73 l -3.63 -3.63 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_location_on.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_location_on.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 12 2 C 8.13 2 5 5.13 5 9 c 0 5.25 7 13 7 13 s 7 -7.75 7 -13 c 0 -3.87 -3.13 -7 -7 -7 Z m 0 9.5 c -1.38 0 -2.5 -1.12 -2.5 -2.5 s 1.12 -2.5 2.5 -2.5 2.5 1.12 2.5 2.5 -1.12 2.5 -2.5 2.5 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_male.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_male.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 9.5 11 c 1.93 0 3.5 1.57 3.5 3.5 S 11.43 18 9.5 18 S 6 16.43 6 14.5 S 7.57 11 9.5 11 Z M 9.5 9 C 6.46 9 4 11.46 4 14.5 S 6.46 20 9.5 20 s 5.5 -2.46 5.5 -5.5 c 0 -1.16 -0.36 -2.23 -0.97 -3.12 L 18 7.42 V 10 h 2 V 4 h -6 v 2 h 2.58 l -3.97 3.97 C 11.73 9.36 10.66 9 9.5 9 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_menu.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_menu.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 3 18 h 18 v -2 H 3 v 2 Z m 0 -5 h 18 v -2 H 3 v 2 Z m 0 -7 v 2 h 18 V 6 H 3 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_more_vert.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_more_vert.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 12 8 c 1.1 0 2 -0.9 2 -2 s -0.9 -2 -2 -2 -2 0.9 -2 2 0.9 2 2 2 Z m 0 2 c -1.1 0 -2 0.9 -2 2 s 0.9 2 2 2 2 -0.9 2 -2 -0.9 -2 -2 -2 Z m 0 6 c -1.1 0 -2 0.9 -2 2 s 0.9 2 2 2 2 -0.9 2 -2 -0.9 -2 -2 -2 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_pending.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_pending.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 12 2 C 6.48 2 2 6.48 2 12 c 0 5.52 4.48 10 10 10 s 10 -4.48 10 -10 C 22 6.48 17.52 2 12 2 Z M 7 13.5 c -0.83 0 -1.5 -0.67 -1.5 -1.5 c 0 -0.83 0.67 -1.5 1.5 -1.5 s 1.5 0.67 1.5 1.5 C 8.5 12.83 7.83 13.5 7 13.5 Z M 12 13.5 c -0.83 0 -1.5 -0.67 -1.5 -1.5 c 0 -0.83 0.67 -1.5 1.5 -1.5 s 1.5 0.67 1.5 1.5 C 13.5 12.83 12.83 13.5 12 13.5 Z M 17 13.5 c -0.83 0 -1.5 -0.67 -1.5 -1.5 c 0 -0.83 0.67 -1.5 1.5 -1.5 s 1.5 0.67 1.5 1.5 C 18.5 12.83 17.83 13.5 17 13.5 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_post_add.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_post_add.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 17 19.22 H 5 V 7 h 7 V 5 H 5 C 3.9 5 3 5.9 3 7 v 12 c 0 1.1 0.9 2 2 2 h 12 c 1.1 0 2 -0.9 2 -2 v -7 h -2 V 19.22 Z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 19 2 h -2 v 3 h -3 c 0.01 0.01 0 2 0 2 h 3 v 2.99 c 0.01 0.01 2 0 2 0 V 7 h 3 V 5 h -3 V 2 Z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 7 9 h 8 v 2 h -8 Z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 7 12 l 0 2 l 8 0 l 0 -2 l -3 0 Z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 7 15 h 8 v 2 h -8 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_save.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_save.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 17 3 H 5 c -1.11 0 -2 0.9 -2 2 v 14 c 0 1.1 0.89 2 2 2 h 14 c 1.1 0 2 -0.9 2 -2 V 7 l -4 -4 Z m -5 16 c -1.66 0 -3 -1.34 -3 -3 s 1.34 -3 3 -3 3 1.34 3 3 -1.34 3 -3 3 Z m 3 -10 H 5 V 5 h 10 v 4 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_search.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_search.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 15.5 14 h -0.79 l -0.28 -0.27 C 15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3 S 3 5.91 3 9.5 5.91 16 9.5 16 c 1.61 0 3.09 -0.59 4.23 -1.57 l 0.27 0.28 v 0.79 l 5 4.99 L 20.49 19 l -4.99 -5 Z m -6 0 C 7.01 14 5 11.99 5 9.5 S 7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14 Z"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_upload_file_filled.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_upload_file_filled.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M440,760h80v-167l64,64 56,-57 -160,-160 -160,160 57,56 63,-63v167ZM240,880q-33,0 -56.5,-23.5T160,800v-640q0,-33 23.5,-56.5T240,80h320l240,240v480q0,33 -23.5,56.5T720,880L240,880ZM520,360h200L520,160v200Z"
+      android:fillColor="#1f1f1f"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_upload_file_outlined.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_upload_file_outlined.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M440,760h80v-167l64,64 56,-57 -160,-160 -160,160 57,56 63,-63v167ZM240,880q-33,0 -56.5,-23.5T160,800v-640q0,-33 23.5,-56.5T240,80h320l240,240v480q0,33 -23.5,56.5T720,880L240,880ZM520,360v-200L240,160v640h480v-440L520,360ZM240,160v200,-200 640,-640Z"
+      android:fillColor="#1f1f1f"/>
+</vector>

--- a/weddell-seal-android/app/src/main/res/drawable/ic_warning.xml
+++ b/weddell-seal-android/app/src/main/res/drawable/ic_warning.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M 1 21 h 22 L 12 2 L 1 21 Z m 12 -3 h -2 v -2 h 2 v 2 Z m 0 -4 h -2 v -4 h 2 v 4 Z"/>
+</vector>

--- a/weddell-seal-android/gradle/libs.versions.toml
+++ b/weddell-seal-android/gradle/libs.versions.toml
@@ -7,8 +7,6 @@ hilt = "2.53.1"
 compose-ui = "1.11.2"
 compose-foundation = "1.11.2"
 compose-material = "1.11.2"
-# material-icons-extended is no longer released past 1.7.8 (see Google Maven metadata)
-compose-material-icons-extended = "1.7.8"
 compose-material3 = "1.4.0"
 compose-runtime = "1.11.2"
 
@@ -47,7 +45,6 @@ compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", versi
 compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "compose-ui" }
 compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "compose-ui" }
 compose-material = { group = "androidx.compose.material", name = "material", version.ref = "compose-material" }
-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "compose-material-icons-extended" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "compose-material3" }
 compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "compose-runtime" }
 compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "compose-runtime" }


### PR DESCRIPTION
- Removed deprecated Material icons in favor of drawable resources for better performance and maintainability.
- Updated various UI components including AppBar, NavMenu, and ObservationItem to use `painterResource` for icon rendering.
- Adjusted related functions to return drawable resource IDs instead of ImageVector for consistency across the application.